### PR TITLE
typo in cc license

### DIFF
--- a/README.md
+++ b/README.md
@@ -125,4 +125,4 @@ nvm use 14.4.0
 
 Built with Docusaurus, [MIT licensed](/LICENSE.txt).
 
-Bedework Guide documentation (e.g., `.md` files in the `/docs` folder) by Nashville Public Library, [Creative Commons licensed](/LICENCE-docs.txt).
+Bedework Guide documentation (e.g., `.md` files in the `/docs` folder) by Nashville Public Library, [Creative Commons licensed](/License-docs.txt).


### PR DESCRIPTION
fixed typo to make the link for CC license to work in the repo README