### PR TITLE
updating link to bedework documentation from docusaurus tutorial 5 min

### DIFF
--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -17,7 +17,7 @@ function HomepageHeader() {
           <Link
             className="button button--secondary button--lg"
             to="/docs/intro">
-            Docusaurus Tutorial - 5min ⏱️
+            Bedework Guide
           </Link>
         </div>
       </div>
@@ -29,8 +29,8 @@ export default function Home() {
   const {siteConfig} = useDocusaurusContext();
   return (
     <Layout
-      title={`Hello from ${siteConfig.title}`}
-      description="Description will go into a meta tag in <head />">
+      title={`${siteConfig.title} | Home`}
+      description="Documentation for using Bedework Enterprise Calendar software at Nashville Public Library">
       <HomepageHeader />
       <main>
         <HomepageFeatures />


### PR DESCRIPTION
# Background

Need to remove the default text referring to a docusaurus tutorial. Point it to the bedework guide.

# Environment

probably can see on github commit

# Testing

Home page should read "Bedework Guide", not "Docusaurus tutorial 5min"

