### PR TITLE
Swapping out Get Covered TN for ACA

### DIFF
--- a/docs/image-library/series-logos-code-block.md
+++ b/docs/image-library/series-logos-code-block.md
@@ -5,6 +5,13 @@ sidebar_position: 1
 
 # Series Logos
 
+## Affordable Care Act
+```
+/public/images/aca-202211080958.jpg
+```
+```
+/public/images/aca-202211080958-thumb.png
+```
 ## Banned Books Week
 ```
 /public/images/NPL_BannedBooksWeek_450 (1)-201908211026.jpg
@@ -151,13 +158,6 @@ sidebar_position: 1
 ```           
 ```
 /public/images/npl-means-business-web-2-202203030358-thumb.png
-```           
-## Open Enrollment (Get Covered TN)
-```           
-/public/images/getcovered-201608310254.png
-```           
-```
-/public/images/getcovered-201608310254.png
 ```           
 ## Panel Discussion
 ```


### PR DESCRIPTION
## Background
I think this ACA image is nice than the 'get covered tn' logo, and no one sees to be using that anyway. Might be hard to find under Open Enrollment

### Steps to Reproduce

### Expected Behavior

### Actual Results

## Environment

## Testing

## Screenshots
