### PR TITLE
updating copy event instructions

### DIFF
--- a/docs/add-events/copy-event.md
+++ b/docs/add-events/copy-event.md
@@ -7,10 +7,12 @@ sidebar_position: 14
 Use existing live events to populate the form when adding new ones, to avoid errors.
 
 1. Login to caladmin
+1. Go under `Approval Queue`
 1. Search for your event by title.
 1. Find, and select, an upcoming or past event on the calendar using the search and date-picker functions.
 1. Choose `Tag or Edit Event`
 1. Under Recurrence, choose `Edit Master Event`
+1. Use back button to return to instance.
 1. Under Event information, choose `Copy Event`
 1. Change the date, time, and any details that may be different for upcoming events.
 1. Choose `Add Event`


### PR DESCRIPTION
## Background
Copy event instructions are missing crucial `back button` trick necessary to reveal the `copy event` button in the UI.
### Steps to Reproduce
1. Login to caladmin as user -approver
1. Follow the instructions as mentioned in the copy-event.md file.
### Expected Behavior
Should copy the event into the approval queue.
### Actual Results

## Environment
https://.../caladmin
## Testing

## Screenshots
